### PR TITLE
allow linking static libraries

### DIFF
--- a/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
+++ b/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required(VERSION 3.7)
 SET(CMAKE_C_COMPILER_WORKS 1)
 SET(CMAKE_C_COMPILER arm-none-eabi-gcc)
 SET(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+set(AS arm-none-eabi-as)
+set(AR arm-none-eabi-ar)
+set(OBJCOPY arm-none-eabi-objcopy)
+set(OBJDUMP arm-none-eabi-objdump)
+set(SIZE arm-none-eabi-size)
 
 
 SET(LINKER_SCRIPT $${CMAKE_SOURCE_DIR}/${linkerScript})


### PR DESCRIPTION
Some of this tools are needed to use CMAKE command target_link_libraries()