### PR TITLE
Add configuration-specific board files and network ports.

### DIFF
--- a/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
@@ -4,9 +4,13 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
 import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfiguration;
 import com.jetbrains.cidr.execution.CidrCommandLineState;
 import com.jetbrains.cidr.execution.CidrExecutableDataHolder;
+import org.jdom.Element;
+import org.jdom.Namespace;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -15,7 +19,18 @@ import org.jetbrains.annotations.Nullable;
  */
 @SuppressWarnings("WeakerAccess")
 public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements CidrExecutableDataHolder {
+    public static final Namespace NAMESPACE = Namespace.getNamespace("ocd", "https://github.com/elmot/clion-embedded-arm/xmlns");
+    public static final String BOARD_FILE = "board-file";
+    public static final String GDB_PORT = "gdb-port";
+    public static final String TELNET_PORT = "telnet-port";
 
+    public static final int NO_PORT = -1;
+
+    @Nullable
+    private String boardFile = null;
+
+    private int gdbPort = NO_PORT;
+    private int telnetPort = NO_PORT;
 
     @SuppressWarnings("WeakerAccess")
     public OpenOcdConfiguration(Project project, ConfigurationFactory configurationFactory, String targetName) {
@@ -28,4 +43,88 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         return new CidrCommandLineState(environment, new OpenOcdLauncher(this));
     }
 
+    @Override
+    public void writeExternal(Element element) throws WriteExternalException {
+        super.writeExternal(element);
+
+        if (boardFile != null) {
+            element.setAttribute(BOARD_FILE, boardFile, NAMESPACE);
+        }
+
+        if (gdbPort != NO_PORT) {
+            element.setAttribute(GDB_PORT, String.valueOf(gdbPort), NAMESPACE);
+        }
+
+        if (telnetPort != NO_PORT) {
+            element.setAttribute(TELNET_PORT, String.valueOf(telnetPort), NAMESPACE);
+        }
+    }
+
+    @Override
+    public void readExternal(Element element) throws InvalidDataException {
+        super.readExternal(element);
+
+        boardFile = element.getAttributeValue(BOARD_FILE, NAMESPACE, null);
+
+        String gdbPort = element.getAttributeValue(GDB_PORT, NAMESPACE);
+        this.gdbPort = gdbPort != null ? Integer.parseInt(gdbPort) : NO_PORT;
+
+        String telnetPort = element.getAttributeValue(TELNET_PORT, NAMESPACE);
+        this.telnetPort = telnetPort != null ? Integer.parseInt(telnetPort) : NO_PORT;
+    }
+
+    @Nullable
+    public String getBoardFile() {
+        return boardFile;
+    }
+
+    public void setBoardFile(@Nullable String boardFile) {
+        this.boardFile = boardFile;
+    }
+
+    public boolean hasBoardFile() {
+        return boardFile != null;
+    }
+
+    public int getGdbPort() {
+        return gdbPort;
+    }
+
+    public void setGdbPort(int gdbPort) {
+        this.gdbPort = gdbPort;
+    }
+
+    public boolean hasGdbPort() {
+        return gdbPort != NO_PORT;
+    }
+
+    public int getTelnetPort() {
+        return telnetPort;
+    }
+
+    public void setTelnetPort(int telnetPort) {
+        this.telnetPort = telnetPort;
+    }
+
+    public boolean hasTelnetPort() {
+        return telnetPort != NO_PORT;
+    }
+
+    public static String actualBoardFile(@Nullable OpenOcdConfiguration configuration,
+                                         @NotNull OpenOcdSettingsState settings) {
+        return configuration != null && configuration.hasBoardFile() ?
+                configuration.getBoardFile() : settings.boardConfigFile;
+    }
+
+    public static int actualGdbPort(@Nullable OpenOcdConfiguration configuration,
+                                    @NotNull OpenOcdSettingsState settings) {
+        return configuration != null && configuration.hasGdbPort() ?
+                configuration.getGdbPort() : settings.gdbPort;
+    }
+
+    public static int actualTelnetPort(@Nullable OpenOcdConfiguration configuration,
+                                       @NotNull OpenOcdSettingsState settings) {
+        return configuration != null && configuration.hasTelnetPort() ?
+                configuration.getTelnetPort() : settings.telnetPort;
+    }
 }

--- a/src/xyz/elmot/clion/openocd/OpenOcdConfigurationEditor.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdConfigurationEditor.java
@@ -1,0 +1,124 @@
+package xyz.elmot.clion.openocd;
+
+import com.intellij.execution.ui.CommonProgramParametersPanel;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.GridBag;
+import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfiguration;
+import com.jetbrains.cidr.cpp.execution.CMakeAppRunConfigurationSettingsEditor;
+import com.jetbrains.cidr.cpp.execution.CMakeBuildConfigurationHelper;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+
+public class OpenOcdConfigurationEditor extends CMakeAppRunConfigurationSettingsEditor {
+    private String openocdHome;
+    private JBTextField gdbPort, telnetPort;
+    private FileChooseInput boardConfigFile;
+
+    public OpenOcdConfigurationEditor(Project project, @NotNull CMakeBuildConfigurationHelper cMakeBuildConfigurationHelper) {
+        super(project, cMakeBuildConfigurationHelper);
+    }
+
+    @Override
+    protected void applyEditorTo(@NotNull CMakeAppRunConfiguration cMakeAppRunConfiguration) throws ConfigurationException {
+        super.applyEditorTo(cMakeAppRunConfiguration);
+
+        OpenOcdConfiguration ocd = (OpenOcdConfiguration) cMakeAppRunConfiguration;
+
+        String boardConfig = boardConfigFile.getText().trim();
+        ocd.setBoardFile(boardConfig.isEmpty() ? null : boardConfig);
+
+        ocd.setGdbPort(parsePort(gdbPort.getText()));
+        ocd.setTelnetPort(parsePort(telnetPort.getText()));
+    }
+
+    @Override
+    protected void resetEditorFrom(@NotNull CMakeAppRunConfiguration cMakeAppRunConfiguration) {
+        super.resetEditorFrom(cMakeAppRunConfiguration);
+
+        OpenOcdConfiguration ocd = (OpenOcdConfiguration) cMakeAppRunConfiguration;
+
+        openocdHome = ocd.getProject().getComponent(OpenOcdSettingsState.class).openOcdHome;
+
+        boardConfigFile.setText("");
+        if (ocd.hasBoardFile()) {
+            boardConfigFile.setText(ocd.getBoardFile());
+        }
+
+        gdbPort.setText("");
+        if (ocd.hasGdbPort()) {
+            gdbPort.setText(String.valueOf(ocd.getGdbPort()));
+        }
+
+        telnetPort.setText("");
+        if (ocd.hasTelnetPort()) {
+            telnetPort.setText(String.valueOf(ocd.getTelnetPort()));
+        }
+    }
+
+    private void portField(JBTextField f) {
+        f.getEmptyText().setText("<default>");
+
+        f.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(FocusEvent e) {
+                if (parsePort(f.getText()) == OpenOcdConfiguration.NO_PORT) {
+                    f.setText("");
+                }
+            }
+        });
+
+        Dimension pref = f.getPreferredSize();
+        f.setPreferredSize(new Dimension(100, pref.height));
+    }
+
+    @Override
+    protected void createEditorInner(JPanel panel, GridBag gridBag) {
+        super.createEditorInner(panel, gridBag);
+
+        for (Component component: panel.getComponents()) {
+            if(component instanceof CommonProgramParametersPanel) {
+                component.setVisible(false);//todo get rid of this hack
+            }
+        }
+
+        panel.add(new JLabel("Board config file"), gridBag.nextLine().next());
+        panel.add(boardConfigFile = new FileChooseInput.BoardCfg("Board config", VfsUtil.getUserHomeDir(),
+                this::getOpenocdHome), gridBag.next().coverLine());
+
+        ((JBTextField) boardConfigFile.getChildComponent()).getEmptyText().setText("<use project default>");
+
+        JPanel portsPanel = new JPanel();
+        portsPanel.setLayout(new FlowLayout(FlowLayout.LEADING));
+
+        portsPanel.add(new JLabel("GDB port: "));
+        portsPanel.add(gdbPort = new JBTextField());
+        portsPanel.add(Box.createHorizontalStrut(10));
+        portsPanel.add(new JLabel("Telnet port: "));
+        portsPanel.add(telnetPort = new JBTextField());
+
+        panel.add(portsPanel, gridBag.nextLine().next().coverLine());
+
+        portField(gdbPort);
+        portField(telnetPort);
+    }
+
+    private String getOpenocdHome() {
+        return openocdHome;
+    }
+
+    private static int parsePort(String text) {
+        try {
+            int r = Integer.parseInt(text);
+            return r <= 0 || r > 65535 ? OpenOcdConfiguration.NO_PORT : r;
+        } catch (NumberFormatException e) {
+            return OpenOcdConfiguration.NO_PORT;
+        }
+    }
+}

--- a/src/xyz/elmot/clion/openocd/OpenOcdConfigurationType.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdConfigurationType.java
@@ -53,17 +53,7 @@ public class OpenOcdConfigurationType extends CMakeRunConfigurationType {
 
     @Override
     public SettingsEditor<? extends CMakeAppRunConfiguration> createEditor(@NotNull Project project) {
-        return new CMakeAppRunConfigurationSettingsEditor(project,getHelper(project)) {
-            @Override
-            protected void createEditorInner(JPanel jPanel, GridBag gridBag) {
-                super.createEditorInner(jPanel, gridBag);
-                for (Component component : jPanel.getComponents()) {
-                    if(component instanceof CommonProgramParametersPanel) {
-                        component.setVisible(false);//todo get rid of this hack
-                    }
-                }
-            }
-        };
+        return new OpenOcdConfigurationEditor(project, getHelper(project));
     }
 
     @NotNull

--- a/src/xyz/elmot/clion/openocd/OpenOcdLauncher.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdLauncher.java
@@ -54,7 +54,7 @@ class OpenOcdLauncher extends CidrLauncher {
         findOpenOcdAction(commandLineState.getEnvironment().getProject()).stopOpenOcd();
         try {
             GeneralCommandLine commandLine = OpenOcdComponent.createOcdCommandLine(commandLineState.getEnvironment().getProject(),
-                    runFile, "reset", true);
+                    openOcdConfiguration, runFile, "reset", true);
             OSProcessHandler osProcessHandler = new OSProcessHandler(commandLine);
             osProcessHandler.addProcessListener(new ProcessAdapter() {
                 @Override
@@ -83,7 +83,9 @@ class OpenOcdLauncher extends CidrLauncher {
         CidrRemoteDebugParameters remoteDebugParameters = new CidrRemoteDebugParameters();
 
         remoteDebugParameters.setSymbolFile(findRunFile(commandLineState).getAbsolutePath());
-        remoteDebugParameters.setRemoteCommand("tcp:localhost:" + ocdSettings.gdbPort);
+
+        int gdbPort = OpenOcdConfiguration.actualGdbPort(openOcdConfiguration, ocdSettings);
+        remoteDebugParameters.setRemoteCommand("tcp:localhost:" + gdbPort);
 
         CPPToolchains.Toolchain toolchain = CPPToolchains.getInstance().getDefaultToolchain();
         if (toolchain != null && !ocdSettings.shippedGdb) {
@@ -156,7 +158,7 @@ class OpenOcdLauncher extends CidrLauncher {
             xDebugSession.stop();
             OpenOcdComponent openOcdComponent = findOpenOcdAction(commandLineState.getEnvironment().getProject());
             openOcdComponent.stopOpenOcd();
-            Future<STATUS> downloadResult = openOcdComponent.startOpenOcd(project, runFile, "reset init");
+            Future<STATUS> downloadResult = openOcdComponent.startOpenOcd(project, openOcdConfiguration, runFile, "reset init");
 
             ThrowableComputable<STATUS, ExecutionException> process = () -> {
                 try {

--- a/src/xyz/elmot/clion/openocd/OpenOcdRun.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdRun.java
@@ -1,5 +1,7 @@
 package xyz.elmot.clion.openocd;
 
+import com.intellij.execution.RunManager;
+import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ConfigurationException;
@@ -21,7 +23,14 @@ public class OpenOcdRun extends AnAction {
     public void actionPerformed(AnActionEvent event) {
         Project project = event.getProject();
         try {
-            getOpenOcdComponent(project).startOpenOcd(project, null, null);
+            RunnerAndConfigurationSettings selectedConfiguration = RunManager.getInstance(project).getSelectedConfiguration();
+            OpenOcdConfiguration configuration = null;
+
+            if (selectedConfiguration != null && selectedConfiguration.getConfiguration() instanceof OpenOcdConfiguration) {
+                configuration = (OpenOcdConfiguration) selectedConfiguration.getConfiguration();
+            }
+
+            getOpenOcdComponent(project).startOpenOcd(project, configuration, null, null);
         } catch (ConfigurationException e) {
             Messages.showErrorDialog(project, e.getLocalizedMessage(), e.getTitle());
         }


### PR DESCRIPTION
That could be useful in cases similar to mine: I have firmware that can act either as master or slave, and two boards. So I need to debug both boards at same time, thus I need different board files (to pick specific board by serial number) and GDB ports per configuration.

Fixes #65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elmot/clion-embedded-arm/84)
<!-- Reviewable:end -->
