### PR TITLE
Ensure reset type is saved and restored correctly

### DIFF
--- a/src/xyz/elmot/clion/openocd/Informational.java
+++ b/src/xyz/elmot/clion/openocd/Informational.java
@@ -27,8 +27,8 @@ public class Informational {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static void showSuccessfulDownloadNotification(Project project) {
-        showMessage(project, MessageType.INFO, "Firmware Download Success");
+    public static void showSuccessfulUploadNotification(Project project) {
+        showMessage(project, MessageType.INFO, "Firmware Upload Success");
     }
 
     public static void showMessage(Project project, MessageType messageType, String message) {
@@ -46,7 +46,7 @@ public class Informational {
     }
 
     @SuppressWarnings("WeakerAccess")
-    public static void showFailedDownloadNotification(Project project) {
+    public static void showFailedUploadNotification(Project project) {
         showMessage(project, MessageType.ERROR,
                 "MCU Communication FAILURE.\nCheck <a href=\""+
                         SETTINGS_PROTOCOL +

--- a/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
@@ -53,40 +53,26 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     }
 
     public enum ResetType {
-        RUN {
-            @Override
-            public String getCommand() {
-                return "init;reset run;";
-            }
-        },
-        INIT {
-            @Override
-            public String getCommand() {
-                return "init;reset init;";
-            }
-        },
-        HALT {
-            @Override
-            public String getCommand() {
-                return "init;reset halt";
-            }
-        },
-        NONE {
-            @Override
-            public String getCommand() {
-                return "";
-            }
-        };
+        RUN("init;reset run"),
+        HALT("init;reset halt"),
+        INIT("init;reset init"),
+        NONE("");
+
+        private String resetCmd;
+
+        ResetType(String cmd) {
+            resetCmd = cmd;
+        }
+
+        public String getCommand() {
+            return resetCmd;
+        }
 
         @Override
         public String toString() {
             return toBeautyString(super.toString());
         }
-
-        public abstract String getCommand();
-
-    }
-
+    };
 
     @SuppressWarnings("WeakerAccess")
     public OpenOcdConfiguration(Project project, ConfigurationFactory configurationFactory, String targetName) {

--- a/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
+++ b/src/xyz/elmot/clion/openocd/OpenOcdConfiguration.java
@@ -1,5 +1,6 @@
 package xyz.elmot.clion.openocd;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.RuntimeConfigurationException;
@@ -30,6 +31,7 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     public static final String ATTR_RESET_TYPE = "reset-type";
     public static final String ATTR_UPLOAD_TYPE = "upload-type";
     public static final ResetType DEFAULT_RESET = ResetType.INIT;
+    public static final UploadType DEFAULT_UPLOAD = UploadType.ALWAYS;
     public static final String ATTR_CUSTOM_RESET = "custom-reset-cmd";
     public static final String ATTR_CUSTOM_UPLOAD = "custom-upload-cmd";
     public static final String DEFAULT_UPLOAD_CMD = "program";
@@ -39,7 +41,7 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
     private String customResetCmd;
     private String customUploadCmd = DEFAULT_UPLOAD_CMD;
 
-    private UploadType uploadType = UploadType.ALWAYS;
+    private UploadType uploadType = DEFAULT_UPLOAD;
     private ResetType resetType = DEFAULT_RESET;
 
     public enum UploadType {
@@ -101,22 +103,30 @@ public class OpenOcdConfiguration extends CMakeAppRunConfiguration implements Ci
         gdbPort = readIntAttr(element, ATTR_GDB_PORT, DEF_GDB_PORT);
         telnetPort = readIntAttr(element, ATTR_TELNET_PORT, DEF_TELNET_PORT);
         resetType = readEnumAttr(element, ATTR_RESET_TYPE, DEFAULT_RESET);
-        uploadType = readEnumAttr(element, ATTR_UPLOAD_TYPE, UploadType.ALWAYS);
+        uploadType = readEnumAttr(element, ATTR_UPLOAD_TYPE, DEFAULT_UPLOAD);
     }
 
-    private int readIntAttr(@NotNull Element element, String name, int def) {
+    @VisibleForTesting
+    public static int readIntAttr(@NotNull Element element, String name, int def) {
         String s = element.getAttributeValue(name, NAMESPACE);
         if (StringUtil.isEmpty(s)) return def;
-        return Integer.parseUnsignedInt(s);
+        try {
+            return Integer.parseUnsignedInt(s);
+        } catch(NumberFormatException e) {
+            // XML data fromat mismatch; return default; TODO: log the issue
+            return def;
+        }
     }
 
-    private String readStringAttr(@NotNull Element element, String name, String def) {
+    @VisibleForTesting
+    public static String readStringAttr(@NotNull Element element, String name, String def) {
         String s = element.getAttributeValue(name, NAMESPACE);
         if (StringUtil.isEmpty(s)) return def;
         return s;
     }
 
-    private <T extends Enum> T readEnumAttr(@NotNull Element element, String name, T def) {
+    @VisibleForTesting
+    public static <T extends Enum> T readEnumAttr(@NotNull Element element, String name, T def) {
         String s = element.getAttributeValue(name, NAMESPACE);
         if (StringUtil.isEmpty(s)) return def;
         try {

--- a/tests/xyz/elmot/clion/openocd/test/OpenOcdConfigurationTest.java
+++ b/tests/xyz/elmot/clion/openocd/test/OpenOcdConfigurationTest.java
@@ -1,0 +1,168 @@
+package xyz.elmot.clion.openocd.test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+import xyz.elmot.clion.openocd.OpenOcdConfiguration;
+
+public class OpenOcdConfigurationTest extends Assert {
+    private static final String XMLNS = OpenOcdConfiguration.NAMESPACE.getPrefix();
+    private static final String XMLNS_URI = OpenOcdConfiguration.NAMESPACE.getURI();
+
+    private static Element toXmlElement(String attrValuePairs) throws JDOMException {
+        SAXBuilder builder = new SAXBuilder();
+        String xmlDocStr = "<?xml version=\"1.0\"?><testdocument xmlns:" + XMLNS + "=\"" +  XMLNS_URI + "\">" +
+                "<testelement" + attrValuePairs + "/></testdocument>";
+
+        Document doc = null;
+        try {
+            doc = builder.build(new StringReader(xmlDocStr));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return doc.getRootElement().getChild("testelement");
+    }
+
+    private static String xmlAttrValue(String attr, String value) {
+        return " " + XMLNS + ":" + attr +"=\"" + value + "\" ";
+    }
+
+    private static <T> boolean ensureAllSameType(T[] values) {
+        Class cls = null;
+        boolean result = true;
+        for (T item : values) {
+            if (cls == null) {
+                cls = item.getClass();
+            } else {
+                result = result && cls.equals(item.getClass());
+            }
+        }
+        return result;
+    }
+
+    enum RegularEnum {
+        ONE(1),
+        TWO(2),
+        THREE(3),
+        FOUR(4);
+
+        private final int value;
+        RegularEnum(int v) {
+            value = v;
+        }
+        int getValue() { return value; }
+    };
+
+    enum EnumWithItemsOfUniqueAnonymousSubtypeEach {
+        ONE {
+            int getItemData() {
+                return 1;
+            }
+        },
+        TWO {
+            int getItemData() {
+                return 2;
+            }
+        },
+        THREE {
+            int getItemData() {
+                return 3;
+            }
+        },
+        FOUR {
+            int getItemData() {
+                return 4;
+            }
+        };
+
+        abstract int getItemData();
+    };
+
+    @Test
+    public void ensureAllSameTypeTest() {
+        assertTrue("All regular enum items have same type",
+                ensureAllSameType(RegularEnum.values()));
+        assertFalse("Subclassed enum items have different types",
+                ensureAllSameType(EnumWithItemsOfUniqueAnonymousSubtypeEach.values()));
+    }
+
+    @Test
+    public void openOcdEnumsTest() {
+        assertTrue("Ensure ResetType enum is regular enum",
+                ensureAllSameType(OpenOcdConfiguration.ResetType.values()));
+        assertTrue("Ensure UploadType enum is regular enum",
+                ensureAllSameType(OpenOcdConfiguration.UploadType.values()));
+    }
+
+    @Test
+    public void readIntAttrTest() throws JDOMException {
+        Element element = toXmlElement(
+                xmlAttrValue("attr1", "5") +
+                xmlAttrValue("attr2", "text")
+        );
+        int attr1 = OpenOcdConfiguration.readIntAttr(element, "attr1", 2);
+        int attr2 = OpenOcdConfiguration.readIntAttr(element, "attr2", 15);
+        int attr3 = OpenOcdConfiguration.readIntAttr(element, "attr3", 29);
+        assertEquals("Can read valid attribute", 5, attr1);
+        assertEquals("Can return default value for non-integer attribute", 15, attr2);
+        assertEquals("Can return default value for missing attribute", 29, attr3);
+    }
+    @Test
+    public void readStringAttrTest() throws JDOMException {
+        Element element = toXmlElement(
+                xmlAttrValue("attr1", "qwerty")
+        );
+        String attr1 = OpenOcdConfiguration.readStringAttr(element, "attr1", "undefined");
+        String attr2 = OpenOcdConfiguration.readStringAttr(element, "attr2", "undefined");
+        assertEquals("Can read valid attribute", "qwerty", attr1);
+        assertEquals("Can return default value for missing attribute", "undefined", attr2);
+    }
+    @Test
+    public void readResetTypeEnumAttrTest() throws JDOMException {
+        final String attrName1 = "resetattr1";
+        final String attrName2 = "resetattr2";
+        final String attrName3 = "resetattr3";
+        Element uploadElement = toXmlElement(
+                xmlAttrValue(attrName1, "HALT") +
+                        xmlAttrValue(attrName2, "INVALID_VALUE")
+        );
+        OpenOcdConfiguration.ResetType resetTypeHalt =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName1, OpenOcdConfiguration.ResetType.INIT);
+        OpenOcdConfiguration.ResetType resetTypeMissing2 =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName2, OpenOcdConfiguration.ResetType.NONE);
+        OpenOcdConfiguration.ResetType resetTypeMissing3 =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName3, OpenOcdConfiguration.ResetType.NONE);
+        assertEquals("Can read valid attribute", resetTypeHalt, OpenOcdConfiguration.ResetType.HALT);
+        assertEquals("Can return default value for invalid attribute", resetTypeMissing2,
+                OpenOcdConfiguration.ResetType.NONE);
+        assertEquals("Can return default value for missing attribute", resetTypeMissing3,
+                OpenOcdConfiguration.ResetType.NONE);
+    }
+    @Test
+    public void readUploadTypeEnumAttrTest() throws JDOMException {
+        final String attrName1 = "uploadattr1";
+        final String attrName2 = "uploadattr2";
+        final String attrName3 = "uploadattr3";
+        Element uploadElement = toXmlElement(
+                xmlAttrValue(attrName1, "UPDATED_ONLY") +
+                        xmlAttrValue(attrName2, "INVALID_VALUE")
+        );
+        OpenOcdConfiguration.UploadType uploadTypeUpdatedOnly =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName1, OpenOcdConfiguration.UploadType.ALWAYS);
+        OpenOcdConfiguration.UploadType uploadTypeMissing2 =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName2, OpenOcdConfiguration.UploadType.NONE);
+        OpenOcdConfiguration.UploadType uploadTypeMissing3 =
+                OpenOcdConfiguration.readEnumAttr(uploadElement, attrName3, OpenOcdConfiguration.UploadType.NONE);
+        assertEquals("Can read valid attribute", uploadTypeUpdatedOnly,
+                OpenOcdConfiguration.UploadType.UPDATED_ONLY);
+        assertEquals("Can return default value for invalid attribute", uploadTypeMissing2,
+                OpenOcdConfiguration.UploadType.NONE);
+        assertEquals("Can return default value for missing attribute", uploadTypeMissing3,
+                OpenOcdConfiguration.UploadType.NONE);
+    }
+}


### PR DESCRIPTION
anonimous subclassing of enum instances for ResetType enum seems
to cause an issue with Enum.valueOf() which does not seem to
work and always returns the default setting (Reset Init).

I reimplemented this enum without subclassing but rather with enum
constructor and it solved the issue for me.

Signed-off-by: Alexey Polyudov <apolyudov@google.com>
Change-Id: I5a016d4ec7be3cd19fd3289c04823a1ab6d7ee9b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elmot/clion-embedded-arm/119)
<!-- Reviewable:end -->
