### PR TITLE
Wrap CMakeLists template to respect maximum line width

### DIFF
--- a/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
+++ b/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
@@ -24,7 +24,9 @@ SET(LINKER_SCRIPT $${CMAKE_SOURCE_DIR}/${linkerScript})
 #Uncomment for software floating point
 #SET(FPU_FLAGS "-mfloat-abi=soft")
 
-SET(COMMON_FLAGS "-mcpu=${mcpu} $${FPU_FLAGS} -mthumb -mthumb-interwork -ffunction-sections -fdata-sections -g -fno-common -fmessage-length=0 ${linkerFlags}")
+SET(COMMON_FLAGS
+    "-mcpu=${mcpu} $${FPU_FLAGS} -mthumb -mthumb-interwork -ffunction-sections -fdata-sections \
+    -g -fno-common -fmessage-length=0 ${linkerFlags}")
 
 SET(CMAKE_CXX_FLAGS_INIT "$${COMMON_FLAGS} -std=c++11")
 SET(CMAKE_C_FLAGS_INIT "$${COMMON_FLAGS} -std=gnu99")
@@ -42,7 +44,8 @@ include_directories(${includes})
 
 add_executable($${PROJECT_NAME}.elf $${SOURCES} $${LINKER_SCRIPT})
 
-set(CMAKE_EXE_LINKER_FLAGS "$${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=$${PROJECT_BINARY_DIR}/$${PROJECT_NAME}.map")
+set(CMAKE_EXE_LINKER_FLAGS
+    "$${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=$${PROJECT_BINARY_DIR}/$${PROJECT_NAME}.map")
 
 set(HEX_FILE $${PROJECT_BINARY_DIR}/$${PROJECT_NAME}.hex)
 set(BIN_FILE $${PROJECT_BINARY_DIR}/$${PROJECT_NAME}.bin)

--- a/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
+++ b/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
@@ -19,7 +19,7 @@ SET(LINKER_SCRIPT $${CMAKE_SOURCE_DIR}/${linkerScript})
 
 #Uncomment for hardware floating point
 #SET(FPU_FLAGS "-mfloat-abi=hard -mfpu=fpv4-sp-d16")
-#add_definitions(-DARM_MATH_CM4 -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1 )
+#add_definitions(-DARM_MATH_CM4 -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1)
 
 #Uncomment for software floating point
 #SET(FPU_FLAGS "-mfloat-abi=soft")
@@ -35,8 +35,8 @@ SET(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,-gc-sections,--print-memory-usage -T $${LIN
 PROJECT(${projectName} C CXX ASM)
 set(CMAKE_CXX_STANDARD 11)
 
-#add_definitions(-DARM_MATH_CM4 -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1 )
-add_definitions(${defines} )
+#add_definitions(-DARM_MATH_CM4 -DARM_MATH_MATRIX_CHECK -DARM_MATH_ROUNDING -D__FPU_PRESENT=1)
+add_definitions(${defines})
 
 file(GLOB_RECURSE SOURCES ${sources})
 


### PR DESCRIPTION
Wrap CMakeLists template so that the generated file better respects a 100 max line width. This allows the generated CMakeLists.txt file to be easier to view side by side with other files in CLion.

This PR does not solve all of the problems, however, since some of the template is, well, templated, and items put into the template should also ideally be separated with newlines instead of spaces so that it respects the right margin.

The remaining fields that could be fixed are:

```
add_definitions(${defines} )
```
Newline wrap each attribute ->

```
add_definitions(
    -D__weak=__attribute__\(\(weak\)\)
    -D__packed=__attribute__\(\(__packed__\)\)
    -DUSE_HAL_DRIVER -DSTM32F407xx )
```

```
include_directories(${includes})
```

Newline wrap each include directory -> 

```
include_directories(
    "Inc"
    "Drivers/STM32F4xx_HAL_Driver/Inc"
    "Drivers/STM32F4xx_HAL_Driver/Inc/Legacy"
    "Drivers/CMSIS/Device/ST/STM32F4xx/Include"
    "Drivers/CMSIS/Include")
```

@elmot Thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elmot/clion-embedded-arm/125)
<!-- Reviewable:end -->
