### PR TITLE
Fix CMAKE_<LANG>_FLAGS not being updated automatically in CLion project

### DIFF
--- a/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
+++ b/resources/xyz/elmot/clion/cubemx/tmpl_CMakeLists.txt
@@ -26,9 +26,9 @@ SET(LINKER_SCRIPT $${CMAKE_SOURCE_DIR}/${linkerScript})
 
 SET(COMMON_FLAGS "-mcpu=${mcpu} $${FPU_FLAGS} -mthumb -mthumb-interwork -ffunction-sections -fdata-sections -g -fno-common -fmessage-length=0 ${linkerFlags}")
 
-SET(CMAKE_CXX_FLAGS_INIT "$${COMMON_FLAGS} -std=c++11")
-SET(CMAKE_C_FLAGS_INIT "$${COMMON_FLAGS} -std=gnu99")
-SET(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,-gc-sections,--print-memory-usage -T $${LINKER_SCRIPT}")
+SET(CMAKE_CXX_FLAGS "$${COMMON_FLAGS} -std=c++11")
+SET(CMAKE_C_FLAGS "$${COMMON_FLAGS} -std=gnu99")
+SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-gc-sections,--print-memory-usage -T $${LINKER_SCRIPT}")
 
 PROJECT(${projectName} C CXX ASM)
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Fixes #124 

This avoids the need for a user to manually reload the CMake project every time they change a compile flag

This has been tested on CLion 2018.2.4 and an STM32F4DISCOVERY board (uploading release builds and single step debugging debug builds).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elmot/clion-embedded-arm/127)
<!-- Reviewable:end -->
